### PR TITLE
Use `isContentEditable` rather than checking the value of `contentEdi…

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -58,7 +58,7 @@ function init() {
       return true;
     }
 
-    if (el.contentEditable == 'true') {
+    if (el.isContentEditable) {
       return true;
     }
 


### PR DESCRIPTION
…table`.

Handles values like `plaintext-only` properly.  Verified that Chrome also shows focus for `plaintext-only`.  Did not check other values.